### PR TITLE
chore(deps): bump https://github.com/cloudsmartio/dex-client-poc.git 

### DIFF
--- a/dependency-matrix/matrix.md
+++ b/dependency-matrix/matrix.md
@@ -1,0 +1,5 @@
+# Dependency Matrix
+
+Dependency | Sources | Version | Mismatched versions
+---------- | ------- | ------- | -------------------
+[cloudsmartio/dex-client-poc](https://github.com/cloudsmartio/dex-client-poc.git) |  | []() | 

--- a/dependency-matrix/matrix.yaml
+++ b/dependency-matrix/matrix.yaml
@@ -1,0 +1,7 @@
+dependencies:
+- host: github.com
+  owner: cloudsmartio
+  repo: dex-client-poc
+  url: https://github.com/cloudsmartio/dex-client-poc.git
+  version: ""
+  versionURL: ""

--- a/repositories/templates/cloudsmartio-dex-client-poc-sr.yaml
+++ b/repositories/templates/cloudsmartio-dex-client-poc-sr.yaml
@@ -1,0 +1,21 @@
+apiVersion: jenkins.io/v1
+kind: SourceRepository
+metadata:
+  creationTimestamp: null
+  labels:
+    owner: cloudsmartio
+    provider: github
+    repository: dex-client-poc
+  name: cloudsmartio-dex-client-poc
+spec:
+  description: Imported application for cloudsmartio/dex-client-poc
+  httpCloneURL: https://github.com/cloudsmartio/dex-client-poc.git
+  org: cloudsmartio
+  provider: https://github.com
+  providerKind: github
+  providerName: github
+  repo: dex-client-poc
+  scheduler:
+    kind: ""
+    name: ""
+  url: https://github.com/cloudsmartio/dex-client-poc.git


### PR DESCRIPTION
Update [cloudsmartio/dex-client-poc](https://github.com/cloudsmartio/dex-client-poc.git) 

Command run was `jx import --pack=javascript --branches .* --url https://github.com/cloudsmartio/dex-client-poc`