### PR TITLE
Remove properties that conflict with jx version

### DIFF
--- a/jx-requirements.yml
+++ b/jx-requirements.yml
@@ -5,9 +5,6 @@ bootConfigURL: https://github.com/jenkins-x/jenkins-x-boot-config.git
 cluster:
   azure: {}
   clusterName: cloudsmart-cluster1
-  devEnvApprovers:
-  - awaddell
-  - leonelcloudsmart
   environmentGitOwner: cloudsmartio
   gitKind: github
   gitName: github
@@ -77,8 +74,6 @@ vault:
   name: jx-vault-cloudsmart-ci-10121901
 velero:
   namespace: velero
-  schedule: 0 8 * * *
-  ttl: ""
 versionStream:
   ref: v1.0.306
   url: https://github.com/jenkins-x/jenkins-x-versions.git


### PR DESCRIPTION
Due to
```
k logs jenkins-x-jxui-84748899c6-vzq94 -c jxui-backend
error: error getting Requirements from TeamSettings to determine if in GitHub app mode: validation failures in requirements from team settings:
velero: Additional property schedule is not allowed
velero: Additional property ttl is not allowed
cluster: Additional property devEnvApprovers is not allowed
```