### PR TITLE
chore(deps): bump https://github.com/cloudsmartio/gitprovider-sync-agent.git 

### DIFF
--- a/dependency-matrix/matrix.md
+++ b/dependency-matrix/matrix.md
@@ -5,3 +5,4 @@ Dependency | Sources | Version | Mismatched versions
 [cloudsmartio/dex-client-poc](https://github.com/cloudsmartio/dex-client-poc.git) |  | []() | 
 [cloudsmartio/application-root](https://github.com/cloudsmartio/application-root.git) |  | []() | 
 [cloudsmartio/agile-project-manager](https://github.com/cloudsmartio/agile-project-manager.git) |  | []() | 
+[cloudsmartio/gitprovider-sync-agent](https://github.com/cloudsmartio/gitprovider-sync-agent.git) |  | []() | 

--- a/dependency-matrix/matrix.yaml
+++ b/dependency-matrix/matrix.yaml
@@ -17,3 +17,9 @@ dependencies:
   url: https://github.com/cloudsmartio/agile-project-manager.git
   version: ""
   versionURL: ""
+- host: github.com
+  owner: cloudsmartio
+  repo: gitprovider-sync-agent
+  url: https://github.com/cloudsmartio/gitprovider-sync-agent.git
+  version: ""
+  versionURL: ""

--- a/repositories/templates/cloudsmartio-gitprovider-sync-agent-sr.yaml
+++ b/repositories/templates/cloudsmartio-gitprovider-sync-agent-sr.yaml
@@ -1,6 +1,8 @@
 apiVersion: jenkins.io/v1
 kind: SourceRepository
 metadata:
+  annotations:
+    jenkins.io/last-build-number-for-master: "3"
   creationTimestamp: null
   labels:
     owner: cloudsmartio

--- a/repositories/templates/cloudsmartio-gitprovider-sync-agent-sr.yaml
+++ b/repositories/templates/cloudsmartio-gitprovider-sync-agent-sr.yaml
@@ -1,0 +1,21 @@
+apiVersion: jenkins.io/v1
+kind: SourceRepository
+metadata:
+  creationTimestamp: null
+  labels:
+    owner: cloudsmartio
+    provider: github
+    repository: gitprovider-sync-agent
+  name: cloudsmartio-gitprovider-sync-agent
+spec:
+  description: Imported application for cloudsmartio/gitprovider-sync-agent
+  httpCloneURL: https://github.com/cloudsmartio/gitprovider-sync-agent.git
+  org: cloudsmartio
+  provider: https://github.com
+  providerKind: github
+  providerName: github
+  repo: gitprovider-sync-agent
+  scheduler:
+    kind: ""
+    name: ""
+  url: https://github.com/cloudsmartio/gitprovider-sync-agent.git


### PR DESCRIPTION
Update [cloudsmartio/gitprovider-sync-agent](https://github.com/cloudsmartio/gitprovider-sync-agent.git) 

Command run was `jx import --pack=typescript --branches .* --url https://github.com/cloudsmartio/gitprovider-sync-agent.git`
<hr />

Update [cloudsmartio/gitprovider-sync-agent](https://github.com/cloudsmartio/gitprovider-sync-agent.git) 

Command run was `jx import --pack=typescript --branches .* --url https://github.com/cloudsmartio/gitprovider-sync-agent.git`